### PR TITLE
Change the ordering of Some Toggle for Consistency

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3067,12 +3067,20 @@
     "Order": "a108_",
     "Type": "Toggle"
   },
+  "WPFToggleHiddenFiles": {
+    "Content": "Show Hidden Files",
+    "Description": "If Enabled then Hidden Files will be shown.",
+    "category": "Customize Preferences",
+    "panel": "2",
+    "Order": "a200_",
+    "Type": "Toggle"
+  },
   "WPFToggleShowExt": {
     "Content": "Show File Extensions",
     "Description": "If enabled then File extensions (e.g., .txt, .jpg) are visible.",
     "category": "Customize Preferences",
     "panel": "2",
-    "Order": "a200_",
+    "Order": "a201_",
     "Type": "Toggle"
   },
   "WPFToggleTaskbarSearch": {
@@ -3080,7 +3088,7 @@
     "Description": "If Enabled Search Button will be on the taskbar.",
     "category": "Customize Preferences",
     "panel": "2",
-    "Order": "a201_",
+    "Order": "a202_",
     "Type": "Toggle"
   },
   "WPFToggleTaskView": {
@@ -3088,20 +3096,12 @@
     "Description": "If Enabled then Task View Button in Taskbar will be shown.",
     "category": "Customize Preferences",
     "panel": "2",
-    "Order": "a202_",
+    "Order": "a203_",
     "Type": "Toggle"
   },
   "WPFToggleTaskbarWidgets": {
     "Content": "Show Widgets Button in Taskbar",
     "Description": "If Enabled then Widgets Button in Taskbar will be shown.",
-    "category": "Customize Preferences",
-    "panel": "2",
-    "Order": "a203_",
-    "Type": "Toggle"
-  },
-  "WPFToggleHiddenFiles": {
-    "Content": "Show Hidden Files",
-    "Description": "If Enabled then Hidden Files will be shown.",
     "category": "Customize Preferences",
     "panel": "2",
     "Order": "a204_",


### PR DESCRIPTION
# Pull Request

## Title
Make the Toggle Buttons in Tweaks Section more consistent

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Read the Title.

## Testing
Tested it on Windows 11 23H2 (Build Number 22631.3737) and had no issues so far with these changes.

## Impact
Nothing to impactful, just a simple re-ordering of Toggles under Tweaks Sections.

## Issue related to PR
No Issues are related to the changes introduced in this PR.

## Additional Information
No additional information.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts. 
